### PR TITLE
Add macOS capturor support to route recorder

### DIFF
--- a/routeRecorder.py
+++ b/routeRecorder.py
@@ -18,7 +18,10 @@ from util import find_pattern_sqdiff, draw_rectangle, screenshot, \
                 get_minimap_loc_size, get_player_location_on_minimap, \
                 to_opencv_hsv, load_yaml, override_cfg, is_mac
 from KeyBoardListener import KeyBoardListener
-from GameWindowCapturor import GameWindowCapturor
+if is_mac():
+    from GameWindowCapturorForMac import GameWindowCapturor
+else:
+    from GameWindowCapturor import GameWindowCapturor
 
 class RouteRecorder():
     '''


### PR DESCRIPTION
## Summary
- enable macOS compatibility in `routeRecorder.py`

## Testing
- `python3 -m py_compile routeRecorder.py GameWindowCapturorForMac.py GameWindowCapturor.py`

------
https://chatgpt.com/codex/tasks/task_e_6856a634753883209f1f4c007a47f948